### PR TITLE
Fix a couple of broken elements in Latte theme

### DIFF
--- a/src/latte.css
+++ b/src/latte.css
@@ -19,9 +19,6 @@ html:not(.style-scope)
   --ctp-mantle: #e6e9ef;
   --ctp-crust: #dce0e8;
 
-  --ytmusic-nav-bar: #e6e9ef;
-  --ytmusic-overlay-text-secondary: #4c4f69;
-
   --ctp-accent: var(--ctp-mauve);
 
   --unthemed-yet: inherit !important;
@@ -832,6 +829,21 @@ yt-formatted-string#suggestion-cell-2x0.title.style-scope.ytmusic-search-suggest
 }
 
 yt-formatted-string#suggestion-cell-3x0.title.style-scope.ytmusic-search-suggestion
+{
+  color: var(--ctp-text) !important;
+}
+
+yt-formatted-string#suggestion-cell-4x0.title.style-scope.ytmusic-search-suggestion
+{
+  color: var(--ctp-text) !important;
+}
+
+yt-formatted-string#suggestion-cell-5x0.title.style-scope.ytmusic-search-suggestion
+{
+  color: var(--ctp-text) !important;
+}
+
+yt-formatted-string#suggestion-cell-6x0.title.style-scope.ytmusic-search-suggestion
 {
   color: var(--ctp-text) !important;
 }
@@ -1697,12 +1709,65 @@ div.cet-titlebar.cet-linux
   color: var(--ctp-text) !important;
 }
 
-ytmusic-search-box[is-bauhaus-sidenav-enabled] #suggestion-list.ytmusic-search-box
+/* Custom fork changes */
+
+ytmusic-app-layout[is-bauhaus-sidenav-enabled] #nav-bar-background.ytmusic-app-layout
 {
-  padding: 0px 0 !important;
+  background: var(--ctp-mantle) !important;
+}
+
+ytmusic-app-layout[is-bauhaus-sidenav-enabled] #mini-guide-background.ytmusic-app-layout
+{
+  background: var(--ctp-mantle) !important;
+}
+
+.title.ytmusic-queue-header-renderer
+{
+  color: var(--ctp-text) !important;
 }
 
 .subtitle.ytmusic-queue-header-renderer
 {
   color: var(--ctp-text) !important;
+}
+
+.content-info-wrapper.ytmusic-player-bar .byline.ytmusic-player-bar
+{
+  color: var(--ctp-mauve) !important;
+}
+
+.song-button.ytmusic-av-toggle, .video-button.ytmusic-av-toggle
+{
+  background-color: var(--ctp-crust) !important;
+  color: var(--ctp-mauve) !important;
+}
+
+tp-yt-paper-toast
+{
+  background: var(--ctp-mantle) !important;
+}
+
+.logo.ytmusic-logo
+{
+  content: url("https://storage.googleapis.com/pe-portal-consumer-prod-wagtail-static/original_images/yt_music_full_rgb_black.png?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=wagtail%40pe-portal-consumer-prod.iam.gserviceaccount.com%2F20231105%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20231105T025917Z&X-Goog-Expires=86400&X-Goog-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dyt_music_full_rgb_black.png&X-Goog-Signature=95840c75482f23e508522e4367f784d4d7c7d26a04e4da8e8d4bcbf87f2df92a93a54d14a7c9dc1c570ab6fe71b01fd581291dc1d2810cda8f1f1e154a8faea40fa46ceb738302fe3d14d31d125208d9c147e5d354347c2619033f9b735b50751d552bab428b8ee37f50a59bef6066a15143a5a476de7104253a4c366d24d8eeb16075ce563fe0428be9d022701afeb15058d3d7abd388e6b526e51fe66be59c42cabbce5c2bcc9642d699ff9fcc438071cc807cff23015410d7bf87ba0aeccdc304b65685d5124e8e87268946fd9087343a7dc6b931cbbff7b73ca136412025c1a53f3d684825e0a323ae950e915f77f7312da0bd8c28e0cd79fce24a661ff5") !important;
+}
+
+ytmusic-search-box[is-bauhaus-sidenav-enabled] #suggestion-list.ytmusic-search-box
+{
+  padding: 0px !important;
+}
+
+.header.ytmusic-card-shelf-header-basic-renderer>yt-formatted-string.ytmusic-card-shelf-header-basic-renderer
+{
+  color: var(--ctp-text) !important;
+}
+
+.immersive-background.ytmusic-card-shelf-renderer:before
+{
+  background-image: linear-gradient(180deg, var(--ctp-base) 0%, var(--ctp-crust) 100%) !important;
+}
+
+ytmusic-responsive-list-item-renderer.ytmusic-card-shelf-renderer
+{
+  background-color: transparent !important;
 }

--- a/src/latte.css
+++ b/src/latte.css
@@ -1734,7 +1734,7 @@ tp-yt-paper-toast
 
 .logo.ytmusic-logo
 {
-  content: url("https://storage.googleapis.com/pe-portal-consumer-prod-wagtail-static/original_images/yt_music_full_rgb_black.png?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=wagtail%40pe-portal-consumer-prod.iam.gserviceaccount.com%2F20231105%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20231105T025917Z&X-Goog-Expires=86400&X-Goog-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dyt_music_full_rgb_black.png&X-Goog-Signature=95840c75482f23e508522e4367f784d4d7c7d26a04e4da8e8d4bcbf87f2df92a93a54d14a7c9dc1c570ab6fe71b01fd581291dc1d2810cda8f1f1e154a8faea40fa46ceb738302fe3d14d31d125208d9c147e5d354347c2619033f9b735b50751d552bab428b8ee37f50a59bef6066a15143a5a476de7104253a4c366d24d8eeb16075ce563fe0428be9d022701afeb15058d3d7abd388e6b526e51fe66be59c42cabbce5c2bcc9642d699ff9fcc438071cc807cff23015410d7bf87ba0aeccdc304b65685d5124e8e87268946fd9087343a7dc6b931cbbff7b73ca136412025c1a53f3d684825e0a323ae950e915f77f7312da0bd8c28e0cd79fce24a661ff5") !important;
+  content: url("https://upload.wikimedia.org/wikipedia/commons/thumb/0/0e/YouTube_Music_full_logo.svg/2560px-YouTube_Music_full_logo.svg.png") !important;
 }
 
 ytmusic-search-box[is-bauhaus-sidenav-enabled] #suggestion-list.ytmusic-search-box

--- a/src/latte.css
+++ b/src/latte.css
@@ -19,6 +19,9 @@ html:not(.style-scope)
   --ctp-mantle: #e6e9ef;
   --ctp-crust: #dce0e8;
 
+  --ytmusic-nav-bar: #e6e9ef;
+  --ytmusic-overlay-text-secondary: #4c4f69;
+
   --ctp-accent: var(--ctp-mauve);
 
   --unthemed-yet: inherit !important;
@@ -1691,5 +1694,15 @@ div.cet-titlebar.cet-linux.inactive
 div.cet-titlebar.cet-linux
 {
   background-color: var(--ctp-mantle) !important;
+  color: var(--ctp-text) !important;
+}
+
+ytmusic-search-box[is-bauhaus-sidenav-enabled] #suggestion-list.ytmusic-search-box
+{
+  padding: 0px 0 !important;
+}
+
+.subtitle.ytmusic-queue-header-renderer
+{
   color: var(--ctp-text) !important;
 }

--- a/src/latte.css
+++ b/src/latte.css
@@ -833,21 +833,6 @@ yt-formatted-string#suggestion-cell-3x0.title.style-scope.ytmusic-search-suggest
   color: var(--ctp-text) !important;
 }
 
-yt-formatted-string#suggestion-cell-4x0.title.style-scope.ytmusic-search-suggestion
-{
-  color: var(--ctp-text) !important;
-}
-
-yt-formatted-string#suggestion-cell-5x0.title.style-scope.ytmusic-search-suggestion
-{
-  color: var(--ctp-text) !important;
-}
-
-yt-formatted-string#suggestion-cell-6x0.title.style-scope.ytmusic-search-suggestion
-{
-  color: var(--ctp-text) !important;
-}
-
 ytmusic-search-box.style-scope.ytmusic-nav-bar
 {
   border: 1px solid var(--ctp-mantle) !important;
@@ -1770,4 +1755,19 @@ ytmusic-search-box[is-bauhaus-sidenav-enabled] #suggestion-list.ytmusic-search-b
 ytmusic-responsive-list-item-renderer.ytmusic-card-shelf-renderer
 {
   background-color: transparent !important;
+}
+
+yt-formatted-string#suggestion-cell-4x0.title.style-scope.ytmusic-search-suggestion
+{
+  color: var(--ctp-text) !important;
+}
+
+yt-formatted-string#suggestion-cell-5x0.title.style-scope.ytmusic-search-suggestion
+{
+  color: var(--ctp-text) !important;
+}
+
+yt-formatted-string#suggestion-cell-6x0.title.style-scope.ytmusic-search-suggestion
+{
+  color: var(--ctp-text) !important;
 }


### PR DESCRIPTION
I created a fork for myself where I fixed a couple of Latte theme issues, that came up with the new update. You are welcome to use any of these changes if you'd like to. I only tested this on the th-ch client, though.

Changes:
- Remove borders from NavBar and MiniGuide
- Fix a couple of texts lines which showed up in white
- Fix notification background being too dark, making text hard to read
- Fix (Audio/Video) selector looking odd
- Replace YTM Logo with one with black text
- Fix black bars in the search bar
- Fix cards being very dark (Cards are the things that appear near the top in search results)