### PR TITLE
ci: add explicit pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,19 @@
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "peaceiris/actions-gh-pages@v3"
+        with:
+          enable_jekyll: false
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          publish_dir: "./src"
+          user_email: "github-actions[bot]@users.noreply.github.com"
+          user_name: "github-actions[bot]"
+          cname: "youtubemusic.catppuccin.com"


### PR DESCRIPTION
This PR brings the pages workflow in line with other ports across the organisation.

I've also added a custom domain `youtubemusic.catppuccin.com`, the previous URL should redirect to this.