### PR TITLE
fix(ytmusic-menu-download): change icon color and text color

### DIFF
--- a/src/frappe.css
+++ b/src/frappe.css
@@ -560,6 +560,11 @@ yt-formatted-string.style-scope.ytmusic-shelf-renderer
   color: var(--ctp-text) !important;
 }
 
+yt-formatted-string.style-scope.ytmusic-menu-service-item-download-renderer
+{
+  color: var(--ctp-text) !important;
+}
+
 yt-formatted-string.strapline.style-scope.ytmusic-shelf-renderer
 {
   color: var(--ctp-text) !important;
@@ -644,6 +649,11 @@ yt-formatted-string.text.style-scope.ytmusic-toggle-menu-service-item-renderer
 }
 
 yt-icon.icon.style-scope.ytmusic-toggle-menu-service-item-renderer
+{
+  fill: var(--ctp-accent) !important;
+}
+
+yt-icon.ytmusic-menu-service-item-download-renderer
 {
   fill: var(--ctp-accent) !important;
 }

--- a/src/latte.css
+++ b/src/latte.css
@@ -560,6 +560,11 @@ yt-formatted-string.style-scope.ytmusic-shelf-renderer
   color: var(--ctp-text) !important;
 }
 
+yt-formatted-string.style-scope.ytmusic-menu-service-item-download-renderer
+{
+  color: var(--ctp-text) !important;
+}
+
 yt-formatted-string.strapline.style-scope.ytmusic-shelf-renderer
 {
   color: var(--ctp-text) !important;
@@ -644,6 +649,11 @@ yt-formatted-string.text.style-scope.ytmusic-toggle-menu-service-item-renderer
 }
 
 yt-icon.icon.style-scope.ytmusic-toggle-menu-service-item-renderer
+{
+  fill: var(--ctp-accent) !important;
+}
+
+yt-icon.ytmusic-menu-service-item-download-renderer
 {
   fill: var(--ctp-accent) !important;
 }

--- a/src/macchiato.css
+++ b/src/macchiato.css
@@ -560,6 +560,11 @@ yt-formatted-string.style-scope.ytmusic-shelf-renderer
   color: var(--ctp-text) !important;
 }
 
+yt-formatted-string.style-scope.ytmusic-menu-service-item-download-renderer
+{
+  color: var(--ctp-text) !important;
+}
+
 yt-formatted-string.strapline.style-scope.ytmusic-shelf-renderer
 {
   color: var(--ctp-text) !important;
@@ -644,6 +649,11 @@ yt-formatted-string.text.style-scope.ytmusic-toggle-menu-service-item-renderer
 }
 
 yt-icon.icon.style-scope.ytmusic-toggle-menu-service-item-renderer
+{
+  fill: var(--ctp-accent) !important;
+}
+
+yt-icon.ytmusic-menu-service-item-download-renderer
 {
   fill: var(--ctp-accent) !important;
 }

--- a/src/mocha.css
+++ b/src/mocha.css
@@ -560,6 +560,11 @@ yt-formatted-string.style-scope.ytmusic-shelf-renderer
   color: var(--ctp-text) !important;
 }
 
+yt-formatted-string.style-scope.ytmusic-menu-service-item-download-renderer
+{
+  color: var(--ctp-text) !important;
+}
+
 yt-formatted-string.strapline.style-scope.ytmusic-shelf-renderer
 {
   color: var(--ctp-text) !important;
@@ -644,6 +649,11 @@ yt-formatted-string.text.style-scope.ytmusic-toggle-menu-service-item-renderer
 }
 
 yt-icon.icon.style-scope.ytmusic-toggle-menu-service-item-renderer
+{
+  fill: var(--ctp-accent) !important;
+}
+
+yt-icon.ytmusic-menu-service-item-download-renderer
 {
   fill: var(--ctp-accent) !important;
 }

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -548,6 +548,11 @@ yt-formatted-string.style-scope.ytmusic-shelf-renderer
   color: var(--ctp-text) !important;
 }
 
+yt-formatted-string.style-scope.ytmusic-menu-service-item-download-renderer
+{
+  color: var(--ctp-text) !important;
+}
+
 yt-formatted-string.strapline.style-scope.ytmusic-shelf-renderer
 {
   color: var(--ctp-text) !important;
@@ -632,6 +637,11 @@ yt-formatted-string.text.style-scope.ytmusic-toggle-menu-service-item-renderer
 }
 
 yt-icon.icon.style-scope.ytmusic-toggle-menu-service-item-renderer
+{
+  fill: var(--ctp-accent) !important;
+}
+
+yt-icon.ytmusic-menu-service-item-download-renderer
 {
   fill: var(--ctp-accent) !important;
 }


### PR DESCRIPTION
Change the text and icon color for the "Download" button in the "More" menu

Before:
![ytmusic-menu-download-example-1](https://github.com/catppuccin/youtubemusic/assets/122896463/ed1bbeee-b578-47e8-a064-ab230ecd922c)

After:
![ytmusic-menu-download-example-2](https://github.com/catppuccin/youtubemusic/assets/122896463/58a9186e-c80d-4fdc-9e07-8100d989151d)
