### PR TITLE
fix(download-promo-renderer): change background and text color

### DIFF
--- a/src/frappe.css
+++ b/src/frappe.css
@@ -586,6 +586,16 @@ ytmusic-search-suggestion
   --iron-icon-fill-color: var(--ctp-accent) !important;
 }
 
+ytmusic-background-promo-renderer[renderer-style="full-height"]
+{
+  background: none !important;
+}
+
+ytmusic-background-promo-renderer[renderer-style="full-height"] .promo-title.ytmusic-background-promo-renderer:not([hidden])
+{
+  color: var(--ctp-text) !important;
+}
+
 a.yt-simple-endpoint.style-scope.ytmusic-responsive-list-item-renderer
 {
   color: var(--ctp-text) !important;

--- a/src/latte.css
+++ b/src/latte.css
@@ -586,6 +586,16 @@ ytmusic-search-suggestion
   --iron-icon-fill-color: var(--ctp-accent) !important;
 }
 
+ytmusic-background-promo-renderer[renderer-style="full-height"]
+{
+  background: none !important;
+}
+
+ytmusic-background-promo-renderer[renderer-style="full-height"] .promo-title.ytmusic-background-promo-renderer:not([hidden])
+{
+  color: var(--ctp-text) !important;
+}
+
 a.yt-simple-endpoint.style-scope.ytmusic-responsive-list-item-renderer
 {
   color: var(--ctp-text) !important;

--- a/src/macchiato.css
+++ b/src/macchiato.css
@@ -586,6 +586,16 @@ ytmusic-search-suggestion
   --iron-icon-fill-color: var(--ctp-accent) !important;
 }
 
+ytmusic-background-promo-renderer[renderer-style="full-height"]
+{
+  background: none !important;
+}
+
+ytmusic-background-promo-renderer[renderer-style="full-height"] .promo-title.ytmusic-background-promo-renderer:not([hidden])
+{
+  color: var(--ctp-text) !important;
+}
+
 a.yt-simple-endpoint.style-scope.ytmusic-responsive-list-item-renderer
 {
   color: var(--ctp-text) !important;

--- a/src/mocha.css
+++ b/src/mocha.css
@@ -586,6 +586,16 @@ ytmusic-search-suggestion
   --iron-icon-fill-color: var(--ctp-accent) !important;
 }
 
+ytmusic-background-promo-renderer[renderer-style="full-height"]
+{
+  background: none !important;
+}
+
+ytmusic-background-promo-renderer[renderer-style="full-height"] .promo-title.ytmusic-background-promo-renderer:not([hidden])
+{
+  color: var(--ctp-text) !important;
+}
+
 a.yt-simple-endpoint.style-scope.ytmusic-responsive-list-item-renderer
 {
   color: var(--ctp-text) !important;

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -574,6 +574,16 @@ ytmusic-search-suggestion
   --iron-icon-fill-color: var(--ctp-accent) !important;
 }
 
+ytmusic-background-promo-renderer[renderer-style="full-height"]
+{
+  background: none !important;
+}
+
+ytmusic-background-promo-renderer[renderer-style="full-height"] .promo-title.ytmusic-background-promo-renderer:not([hidden])
+{
+  color: var(--ctp-text) !important;
+}
+
 a.yt-simple-endpoint.style-scope.ytmusic-responsive-list-item-renderer
 {
   color: var(--ctp-text) !important;


### PR DESCRIPTION
Change the background and text color of the download promo.

Before:
![download-promo-renderer-example-1](https://github.com/catppuccin/youtubemusic/assets/122896463/4bededab-e05c-467e-bc86-a4159a3b2057)


After:
![download-promo-renderer-example-2](https://github.com/catppuccin/youtubemusic/assets/122896463/6081a99b-e3c6-4abf-832e-31cda1d532a8)

