### PR TITLE
fix(button-icon-colors): add the right icon colors

### DIFF
--- a/src/frappe.css
+++ b/src/frappe.css
@@ -302,6 +302,16 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
   fill: var(--ctp-base) !important;
 }
 
+.play-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
+.radio-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;

--- a/src/frappe.css
+++ b/src/frappe.css
@@ -312,6 +312,10 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
   fill: var(--ctp-base) !important;
 }
 
+ytmusic-tabs.stuck {
+	background-color: var(--catppuccin-mantle) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;

--- a/src/latte.css
+++ b/src/latte.css
@@ -302,6 +302,16 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
   fill: var(--ctp-base) !important;
 }
 
+.play-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
+.radio-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;

--- a/src/latte.css
+++ b/src/latte.css
@@ -312,6 +312,10 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
   fill: var(--ctp-base) !important;
 }
 
+ytmusic-tabs.stuck {
+	background-color: var(--catppuccin-mantle) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;

--- a/src/macchiato.css
+++ b/src/macchiato.css
@@ -302,6 +302,16 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
   fill: var(--ctp-base) !important;
 }
 
+.play-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
+.radio-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;

--- a/src/macchiato.css
+++ b/src/macchiato.css
@@ -312,6 +312,10 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
   fill: var(--ctp-base) !important;
 }
 
+ytmusic-tabs.stuck {
+	background-color: var(--catppuccin-mantle) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;

--- a/src/mocha.css
+++ b/src/mocha.css
@@ -302,6 +302,16 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
   fill: var(--ctp-base) !important;
 }
 
+.play-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
+.radio-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;

--- a/src/mocha.css
+++ b/src/mocha.css
@@ -312,6 +312,10 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
   fill: var(--ctp-base) !important;
 }
 
+ytmusic-tabs.stuck {
+	background-color: var(--catppuccin-mantle) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -290,6 +290,16 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
   fill: var(--ctp-base) !important;
 }
 
+.play-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
+.radio-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -300,6 +300,10 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
   fill: var(--ctp-base) !important;
 }
 
+ytmusic-tabs.stuck {
+	background-color: var(--catppuccin-mantle) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;


### PR DESCRIPTION
Add the right icon colors for the `play-button` (shuffle on artist page) and the `radio-button` (radio on artist page). Add also the background for `ytmusic-tabs.stuck`.

Before:
![image](https://github.com/catppuccin/youtubemusic/assets/122896463/fe492e11-e241-44d6-9e1a-c5bc050af1f1)
After:
![image](https://github.com/catppuccin/youtubemusic/assets/122896463/2cedf54b-3a75-463d-9e8e-a3933c589730)