### PR TITLE
fix(ytmusic-borders): change colors 

### DIFF
--- a/src/frappe.css
+++ b/src/frappe.css
@@ -110,7 +110,7 @@ ytmusic-list-item-renderer
 
 ytmusic-responsive-list-item-renderer
 {
-  background-color: var(--ctp-base) !important;
+  background-color: var(--ctp-mantle) !important;
 }
 
 ytmusic-player-queue-item

--- a/src/frappe.css
+++ b/src/frappe.css
@@ -297,6 +297,11 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
 	fill: var(--ctp-base) !important;
 }
 
+.watch-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;
@@ -1614,7 +1619,6 @@ yt-formatted-string.title.style-scope.ytmusic-setting-single-option-menu-rendere
 {
   color: var(--ctp-accent) !important;
   border-color: var(--ctp-accent) !important;
-  height: 40px !important;
   border-radius: 36px !important;
 }
 

--- a/src/latte.css
+++ b/src/latte.css
@@ -110,7 +110,7 @@ ytmusic-list-item-renderer
 
 ytmusic-responsive-list-item-renderer
 {
-  background-color: var(--ctp-base) !important;
+  background-color: var(--ctp-mantle) !important;
 }
 
 ytmusic-player-queue-item

--- a/src/latte.css
+++ b/src/latte.css
@@ -297,6 +297,11 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
 	fill: var(--ctp-base) !important;
 }
 
+.watch-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;
@@ -1614,7 +1619,6 @@ yt-formatted-string.title.style-scope.ytmusic-setting-single-option-menu-rendere
 {
   color: var(--ctp-accent) !important;
   border-color: var(--ctp-accent) !important;
-  height: 40px !important;
   border-radius: 36px !important;
 }
 

--- a/src/macchiato.css
+++ b/src/macchiato.css
@@ -110,7 +110,7 @@ ytmusic-list-item-renderer
 
 ytmusic-responsive-list-item-renderer
 {
-  background-color: var(--ctp-base) !important;
+  background-color: var(--ctp-mantle) !important;
 }
 
 ytmusic-player-queue-item

--- a/src/macchiato.css
+++ b/src/macchiato.css
@@ -297,6 +297,11 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
 	fill: var(--ctp-base) !important;
 }
 
+.watch-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;
@@ -1614,7 +1619,6 @@ yt-formatted-string.title.style-scope.ytmusic-setting-single-option-menu-rendere
 {
   color: var(--ctp-accent) !important;
   border-color: var(--ctp-accent) !important;
-  height: 40px !important;
   border-radius: 36px !important;
 }
 

--- a/src/mocha.css
+++ b/src/mocha.css
@@ -110,7 +110,7 @@ ytmusic-list-item-renderer
 
 ytmusic-responsive-list-item-renderer
 {
-  background-color: var(--ctp-base) !important;
+  background-color: var(--ctp-mantle) !important;
 }
 
 ytmusic-player-queue-item

--- a/src/mocha.css
+++ b/src/mocha.css
@@ -297,6 +297,11 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
 	fill: var(--ctp-base) !important;
 }
 
+.watch-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;
@@ -1614,7 +1619,6 @@ yt-formatted-string.title.style-scope.ytmusic-setting-single-option-menu-rendere
 {
   color: var(--ctp-accent) !important;
   border-color: var(--ctp-accent) !important;
-  height: 40px !important;
   border-radius: 36px !important;
 }
 

--- a/src/youtubemusic.user.css
+++ b/src/youtubemusic.user.css
@@ -1,7 +1,7 @@
 /*==UserStyle==
 @name           Youtube Music Catppuccin
 @namespace      github.com/catppuccin/youtubemusic
-@version        0.4.1
+@version        0.4.2
 @description    Soothing pastel theme for Youtube Music
 @author         Catppuccin
 @updateURL      https://raw.githubusercontent.com/catppuccin/youtubemusic/main/src/youtubemusic.user.css

--- a/src/youtubemusic.user.css
+++ b/src/youtubemusic.user.css
@@ -1,7 +1,7 @@
 /*==UserStyle==
 @name           Youtube Music Catppuccin
 @namespace      github.com/catppuccin/youtubemusic
-@version        0.4.2
+@version        0.4.3
 @description    Soothing pastel theme for Youtube Music
 @author         Catppuccin
 @updateURL      https://raw.githubusercontent.com/catppuccin/youtubemusic/main/src/youtubemusic.user.css

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -98,7 +98,7 @@ ytmusic-list-item-renderer
 
 ytmusic-responsive-list-item-renderer
 {
-  background-color: var(--ctp-base) !important;
+  background-color: var(--ctp-mantle) !important;
 }
 
 ytmusic-player-queue-item

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -285,6 +285,11 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
 	fill: var(--ctp-base) !important;
 }
 
+.watch-button .yt-spec-button-shape-next__icon > yt-icon
+{
+  fill: var(--ctp-base) !important;
+}
+
 paper-icon-button.ytmusic-like-button-renderer
 {
   color: var(--ctp-text) !important;
@@ -1602,7 +1607,6 @@ yt-formatted-string.title.style-scope.ytmusic-setting-single-option-menu-rendere
 {
   color: var(--ctp-accent) !important;
   border-color: var(--ctp-accent) !important;
-  height: 40px !important;
   border-radius: 36px !important;
 }
 

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -1198,7 +1198,7 @@ ytd-multi-page-menu-renderer.style-scope.ytmusic-popup-container
 
 ytd-multi-page-menu-renderer
 {
-  border-radius: 2px !important;
+  border-radius: 5px !important;
 }
 
 ytmusic-setting-category-collection-renderer.style-scope.ytmusic-settings-page


### PR DESCRIPTION
Made in favor of #37 

I think these changes are more in line with the policies regarding ["we dont change the appearance, only the colors"](https://github.com/catppuccin/userstyles/blob/main/docs/CONTRIBUTING.md#opinionated-changes). 

Before:
![image](https://github.com/catppuccin/youtubemusic/assets/122896463/d8aaab81-5b96-47ec-88f7-60a1ce1ae830) ![image](https://github.com/catppuccin/youtubemusic/assets/122896463/c0661ca9-6296-448b-b9a3-7196ad73e6a4) ![image](https://github.com/catppuccin/youtubemusic/assets/122896463/19e6e6f1-9552-4a8e-9142-a35de0ffb38f)


After:
![image](https://github.com/catppuccin/youtubemusic/assets/122896463/de1376ae-eea7-43d7-89b7-a5e38a8e997b) ![image](https://github.com/catppuccin/youtubemusic/assets/122896463/de108f7b-d714-4484-b70b-307ae8db456f) ![image](https://github.com/catppuccin/youtubemusic/assets/122896463/da208f0f-e042-43ca-a7ce-7ade5508af45)