### PR TITLE
release: 0.4.4

### DIFF
--- a/src/frappe.css
+++ b/src/frappe.css
@@ -102,7 +102,7 @@ ytmusic-list-item-renderer
 
 ytmusic-responsive-list-item-renderer
 {
-  background-color: var(--ctp-mantle) !important;
+  background-color: var(--ctp-base) !important;
 }
 
 ytmusic-player-queue-item
@@ -1805,21 +1805,37 @@ ytmusic-guide-entry-renderer:not([is-primary]) #play-button.ytmusic-guide-entry-
   color: none !important;
 }
 
-/* Client-specific changes */
-
-div.cet-titlebar.cet-linux.inactive
-{
-  background-color: var(--ctp-mantle) !important;
-  color: var(--ctp-text) !important;
-}
-
-div.cet-titlebar.cet-linux
-{
-  background-color: var(--ctp-mantle) !important;
-  color: var(--ctp-text) !important;
-}
-
 .go3564761155 {
   background-color: var(--ctp-mantle) !important;
   color: var(--ctp-text) !important;
+}
+
+ytmusic-player-bar:is([repeat-mode=NONE]) .repeat.ytmusic-player-bar {
+  opacity: 0.5;
+}
+
+#nav-bar-background.ytmusic-app-layout {
+  background: var(--ctp-mantle) !important;
+}
+
+ytmusic-app-layout[is-bauhaus-sidenav-enabled] #nav-bar-background.ytmusic-app-layout
+{
+  border-bottom: none !important;
+}
+
+ytmusic-nav-bar[enable-bauhaus-style] .app-bar-button.ytmusic-nav-bar {
+  background: var(--ctp-accent) !important;
+  color: var(--ctp-base) !important;
+}
+
+yt-formatted-string.ytmusic-guide-signin-promo-renderer {
+  color: var(--ctp-subtext) !important;
+}
+
+yt-icon.ytmusic-guide-signin-promo-renderer {
+  fill: var(--ctp-accent) !important;
+}
+
+.action-text.ytmusic-guide-signin-promo-renderer {
+  color: var(--ctp-accent) !important;
 }

--- a/src/latte.css
+++ b/src/latte.css
@@ -102,7 +102,7 @@ ytmusic-list-item-renderer
 
 ytmusic-responsive-list-item-renderer
 {
-  background-color: var(--ctp-mantle) !important;
+  background-color: var(--ctp-base) !important;
 }
 
 ytmusic-player-queue-item
@@ -1805,23 +1805,39 @@ ytmusic-guide-entry-renderer:not([is-primary]) #play-button.ytmusic-guide-entry-
   color: none !important;
 }
 
-/* Client-specific changes */
-
-div.cet-titlebar.cet-linux.inactive
-{
-  background-color: var(--ctp-mantle) !important;
-  color: var(--ctp-text) !important;
-}
-
-div.cet-titlebar.cet-linux
-{
-  background-color: var(--ctp-mantle) !important;
-  color: var(--ctp-text) !important;
-}
-
 .go3564761155 {
   background-color: var(--ctp-mantle) !important;
   color: var(--ctp-text) !important;
+}
+
+ytmusic-player-bar:is([repeat-mode=NONE]) .repeat.ytmusic-player-bar {
+  opacity: 0.5;
+}
+
+#nav-bar-background.ytmusic-app-layout {
+  background: var(--ctp-mantle) !important;
+}
+
+ytmusic-app-layout[is-bauhaus-sidenav-enabled] #nav-bar-background.ytmusic-app-layout
+{
+  border-bottom: none !important;
+}
+
+ytmusic-nav-bar[enable-bauhaus-style] .app-bar-button.ytmusic-nav-bar {
+  background: var(--ctp-accent) !important;
+  color: var(--ctp-base) !important;
+}
+
+yt-formatted-string.ytmusic-guide-signin-promo-renderer {
+  color: var(--ctp-subtext) !important;
+}
+
+yt-icon.ytmusic-guide-signin-promo-renderer {
+  fill: var(--ctp-accent) !important;
+}
+
+.action-text.ytmusic-guide-signin-promo-renderer {
+  color: var(--ctp-accent) !important;
 }
 
 /* Custom fork changes */

--- a/src/macchiato.css
+++ b/src/macchiato.css
@@ -102,7 +102,7 @@ ytmusic-list-item-renderer
 
 ytmusic-responsive-list-item-renderer
 {
-  background-color: var(--ctp-mantle) !important;
+  background-color: var(--ctp-base) !important;
 }
 
 ytmusic-player-queue-item
@@ -1805,21 +1805,37 @@ ytmusic-guide-entry-renderer:not([is-primary]) #play-button.ytmusic-guide-entry-
   color: none !important;
 }
 
-/* Client-specific changes */
-
-div.cet-titlebar.cet-linux.inactive
-{
-  background-color: var(--ctp-mantle) !important;
-  color: var(--ctp-text) !important;
-}
-
-div.cet-titlebar.cet-linux
-{
-  background-color: var(--ctp-mantle) !important;
-  color: var(--ctp-text) !important;
-}
-
 .go3564761155 {
   background-color: var(--ctp-mantle) !important;
   color: var(--ctp-text) !important;
+}
+
+ytmusic-player-bar:is([repeat-mode=NONE]) .repeat.ytmusic-player-bar {
+  opacity: 0.5;
+}
+
+#nav-bar-background.ytmusic-app-layout {
+  background: var(--ctp-mantle) !important;
+}
+
+ytmusic-app-layout[is-bauhaus-sidenav-enabled] #nav-bar-background.ytmusic-app-layout
+{
+  border-bottom: none !important;
+}
+
+ytmusic-nav-bar[enable-bauhaus-style] .app-bar-button.ytmusic-nav-bar {
+  background: var(--ctp-accent) !important;
+  color: var(--ctp-base) !important;
+}
+
+yt-formatted-string.ytmusic-guide-signin-promo-renderer {
+  color: var(--ctp-subtext) !important;
+}
+
+yt-icon.ytmusic-guide-signin-promo-renderer {
+  fill: var(--ctp-accent) !important;
+}
+
+.action-text.ytmusic-guide-signin-promo-renderer {
+  color: var(--ctp-accent) !important;
 }

--- a/src/mocha.css
+++ b/src/mocha.css
@@ -102,7 +102,7 @@ ytmusic-list-item-renderer
 
 ytmusic-responsive-list-item-renderer
 {
-  background-color: var(--ctp-mantle) !important;
+  background-color: var(--ctp-base) !important;
 }
 
 ytmusic-player-queue-item
@@ -1805,21 +1805,37 @@ ytmusic-guide-entry-renderer:not([is-primary]) #play-button.ytmusic-guide-entry-
   color: none !important;
 }
 
-/* Client-specific changes */
-
-div.cet-titlebar.cet-linux.inactive
-{
-  background-color: var(--ctp-mantle) !important;
-  color: var(--ctp-text) !important;
-}
-
-div.cet-titlebar.cet-linux
-{
-  background-color: var(--ctp-mantle) !important;
-  color: var(--ctp-text) !important;
-}
-
 .go3564761155 {
   background-color: var(--ctp-mantle) !important;
   color: var(--ctp-text) !important;
+}
+
+ytmusic-player-bar:is([repeat-mode=NONE]) .repeat.ytmusic-player-bar {
+  opacity: 0.5;
+}
+
+#nav-bar-background.ytmusic-app-layout {
+  background: var(--ctp-mantle) !important;
+}
+
+ytmusic-app-layout[is-bauhaus-sidenav-enabled] #nav-bar-background.ytmusic-app-layout
+{
+  border-bottom: none !important;
+}
+
+ytmusic-nav-bar[enable-bauhaus-style] .app-bar-button.ytmusic-nav-bar {
+  background: var(--ctp-accent) !important;
+  color: var(--ctp-base) !important;
+}
+
+yt-formatted-string.ytmusic-guide-signin-promo-renderer {
+  color: var(--ctp-subtext) !important;
+}
+
+yt-icon.ytmusic-guide-signin-promo-renderer {
+  fill: var(--ctp-accent) !important;
+}
+
+.action-text.ytmusic-guide-signin-promo-renderer {
+  color: var(--ctp-accent) !important;
 }

--- a/src/youtubemusic.user.css
+++ b/src/youtubemusic.user.css
@@ -1,7 +1,7 @@
 /*==UserStyle==
 @name           Youtube Music Catppuccin
 @namespace      github.com/catppuccin/youtubemusic
-@version        0.4.3
+@version        0.4.4
 @description    Soothing pastel theme for Youtube Music
 @author         Catppuccin
 @updateURL      https://raw.githubusercontent.com/catppuccin/youtubemusic/main/src/youtubemusic.user.css

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -1830,6 +1830,10 @@ ytmusic-nav-bar[enable-bauhaus-style] .app-bar-button.ytmusic-nav-bar {
   color: var(--ctp-base) !important;
 }
 
+yt-formatted-string.ytmusic-guide-signin-promo-renderer {
+  color: var(--ctp-subtext) !important;
+}
+
 {%- if not flavor.dark %}
 
 /* Custom fork changes */

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -1820,6 +1820,11 @@ ytmusic-player-bar:is([repeat-mode=NONE]) .repeat.ytmusic-player-bar {
   background: var(--ctp-mantle) !important;
 }
 
+ytmusic-app-layout[is-bauhaus-sidenav-enabled] #nav-bar-background.ytmusic-app-layout
+{
+  border-bottom: none !important;
+}
+
 {%- if not flavor.dark %}
 
 /* Custom fork changes */

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -1816,6 +1816,10 @@ ytmusic-player-bar:is([repeat-mode=NONE]) .repeat.ytmusic-player-bar {
   opacity: 0.5;
 }
 
+#nav-bar-background.ytmusic-app-layout {
+  background: var(--ctp-mantle) !important;
+}
+
 {%- if not flavor.dark %}
 
 /* Custom fork changes */

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -1820,6 +1820,14 @@ yt-formatted-string.ytmusic-guide-signin-promo-renderer {
   color: var(--ctp-subtext) !important;
 }
 
+yt-icon.ytmusic-guide-signin-promo-renderer {
+  fill: var(--ctp-accent) !important;
+}
+
+.action-text.ytmusic-guide-signin-promo-renderer {
+  color: var(--ctp-accent) !important;
+}
+
 {%- if not flavor.dark %}
 
 /* Custom fork changes */

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -1825,6 +1825,11 @@ ytmusic-app-layout[is-bauhaus-sidenav-enabled] #nav-bar-background.ytmusic-app-l
   border-bottom: none !important;
 }
 
+ytmusic-nav-bar[enable-bauhaus-style] .app-bar-button.ytmusic-nav-bar {
+  background: var(--ctp-accent) !important;
+  color: var(--ctp-base) !important;
+}
+
 {%- if not flavor.dark %}
 
 /* Custom fork changes */

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -90,7 +90,7 @@ ytmusic-list-item-renderer
 
 ytmusic-responsive-list-item-renderer
 {
-  background-color: var(--ctp-mantle) !important;
+  background-color: var(--ctp-base) !important;
 }
 
 ytmusic-player-queue-item

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -1793,20 +1793,6 @@ ytmusic-guide-entry-renderer:not([is-primary]) #play-button.ytmusic-guide-entry-
   color: none !important;
 }
 
-/* Client-specific changes */
-
-div.cet-titlebar.cet-linux.inactive
-{
-  background-color: var(--ctp-mantle) !important;
-  color: var(--ctp-text) !important;
-}
-
-div.cet-titlebar.cet-linux
-{
-  background-color: var(--ctp-mantle) !important;
-  color: var(--ctp-text) !important;
-}
-
 .go3564761155 {
   background-color: var(--ctp-mantle) !important;
   color: var(--ctp-text) !important;

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -1812,6 +1812,10 @@ div.cet-titlebar.cet-linux
   color: var(--ctp-text) !important;
 }
 
+ytmusic-player-bar:is([repeat-mode=NONE]) .repeat.ytmusic-player-bar {
+  opacity: 0.5;
+}
+
 {%- if not flavor.dark %}
 
 /* Custom fork changes */


### PR DESCRIPTION
chore: bump version and build variants
fix: incorrectly colored sign in promo on collapsed sidebar
fix: incorrect background on songs
refactor: deprecate linux fixes
the th-ch client that used them now switched to a gtk themed top bar
fix: incorrect sign in promo text color
fix: incorrect colors on sign in button
fix: remove extra border on navbar bottom
fix: incorrect corner color on top navbar (fixes #47)
fix: indicate repeat mode more clearly (fixes #46)