### PR TITLE
Updated Tabs Variable Name

### DIFF
--- a/src/frappe.css
+++ b/src/frappe.css
@@ -305,7 +305,7 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
 }
 
 ytmusic-tabs.stuck {
-	background-color: var(--catppuccin-mantle) !important;
+	background-color: var(--ctp-mantle) !important;
 }
 
 paper-icon-button.ytmusic-like-button-renderer

--- a/src/latte.css
+++ b/src/latte.css
@@ -305,7 +305,7 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
 }
 
 ytmusic-tabs.stuck {
-	background-color: var(--catppuccin-mantle) !important;
+	background-color: var(--ctp-mantle) !important;
 }
 
 paper-icon-button.ytmusic-like-button-renderer

--- a/src/macchiato.css
+++ b/src/macchiato.css
@@ -305,7 +305,7 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
 }
 
 ytmusic-tabs.stuck {
-	background-color: var(--catppuccin-mantle) !important;
+	background-color: var(--ctp-mantle) !important;
 }
 
 paper-icon-button.ytmusic-like-button-renderer

--- a/src/mocha.css
+++ b/src/mocha.css
@@ -305,7 +305,7 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
 }
 
 ytmusic-tabs.stuck {
-	background-color: var(--catppuccin-mantle) !important;
+	background-color: var(--ctp-mantle) !important;
 }
 
 paper-icon-button.ytmusic-like-button-renderer

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -293,7 +293,7 @@ yt-icon.icon.style-scope.ytmusic-play-button-renderer {
 }
 
 ytmusic-tabs.stuck {
-	background-color: var(--catppuccin-mantle) !important;
+	background-color: var(--ctp-mantle) !important;
 }
 
 paper-icon-button.ytmusic-like-button-renderer


### PR DESCRIPTION
This PR fixes a bug where a variable name was written incorrectly.

In one place, on the library "tabs" specifically, the variable name `--ctp-mantle` was miswritten as `--catppuccin-mantle`, causing the tabs bar to have no background.