### PR TITLE
refactor: add whiskers check, delete justfile & add explicit `^`

### DIFF
--- a/.github/workflows/whiskers-check.yml
+++ b/.github/workflows/whiskers-check.yml
@@ -1,0 +1,15 @@
+name: whiskers
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  run:
+    uses: catppuccin/actions/.github/workflows/whiskers-check.yml@v1
+    with:
+      args: youtubemusic.tera
+    secrets: inherit

--- a/justfile
+++ b/justfile
@@ -1,5 +1,0 @@
-_default:
-  @just --list
-
-build:
-  whiskers youtubemusic.tera

--- a/youtubemusic.tera
+++ b/youtubemusic.tera
@@ -1,7 +1,7 @@
 ---
 accent: mauve
 whiskers:
-  version: "2.3.0"
+  version: "^2.3.0"
   matrix:
     - flavor
   filename: "src/{{ flavor.identifier }}.css"


### PR DESCRIPTION
Aligns to newer organisation standards by removing the justfile, adding an explicit `^` into the whiskers version and a ci workflow to verify the generated themes in source match the template.